### PR TITLE
chore: add `license` property to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/stubborn-fs",
   "description": "Stubborn versions of Node's fs functions that try really hard to do their job.",
   "version": "1.2.5",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Hi,

If you wouldn't mind accepting this and publishing a release, downstream tools are having trouble reporting the package license dependencies.

Thanks!