### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/stubborn-fs",
   "description": "Stubborn versions of Node's fs functions that try really hard to do their job.",
   "version": "1.2.5",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Some tools like for example [LicenseFinder](https://github.com/pivotal/LicenseFinder) rely on the license property from package.json. If not present, the license is reported as unknown