### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/stubborn-fs",
   "description": "Stubborn versions of Node's fs functions that try really hard to do their job.",
   "version": "1.2.5",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
So that the license properly displays on npmjs.com and is detected by automated tooling